### PR TITLE
feat: Add T-Display-S3-USB-Device — BLE-to-USB MIDI bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 ├── T-Display-S3-Piano-Debug      #  MIDI event monitor with raw packet inspector (ESP32_Host_MIDI)
 ├── T-Display-S3-Gingoduino       #  Real-time chord detection and harmonic analysis (ESP32_Host_MIDI + Gingoduino)
 ├── T-Display-S3-Queue            #  MIDI event queue visualizer for debugging (ESP32_Host_MIDI)
+├── T-Display-S3-USB-Device       #  BLE-to-USB MIDI bridge — T-Display-S3 as USB MIDI interface (ESP32_Host_MIDI)
 ├── TFT_Rainbow                  #  TFT_eSPI example
 ├── factory                      #  factory example
 ├── lv_demos                     #  lvgl demo                        

--- a/examples/T-Display-S3-USB-Device/ST7789_Handler.cpp
+++ b/examples/T-Display-S3-USB-Device/ST7789_Handler.cpp
@@ -1,0 +1,114 @@
+#include "ST7789_Handler.h"
+#include "mapping.h"
+#include <cstdio>
+#include <cstring>
+
+ST7789_Handler display;
+
+ST7789_Handler::ST7789_Handler() : _eventCount(0) {
+    memset(_events, 0, sizeof(_events));
+}
+
+void ST7789_Handler::_fillRow(int y, int h, uint32_t bg) {
+    _tft.fillRect(0, y, USB_DISPLAY_W, h, bg);
+}
+
+void ST7789_Handler::_drawText(int x, int y, uint32_t color, uint32_t bg,
+                               uint8_t size, const char* text) {
+    _tft.setTextSize(size);
+    _tft.setTextColor(color, bg);
+    _tft.drawString(text, x, y);
+}
+
+// Draws a status row: colored dot + label text.
+void ST7789_Handler::_drawStatusRow(int y, int h, uint32_t dotColor, const char* label) {
+    _fillRow(y, h, USB_COL_BG);
+    _tft.fillCircle(USB_MARGIN + 4, y + h / 2, 4, dotColor);
+    _drawText(USB_MARGIN + 14, y + (h - 8) / 2, USB_COL_WHITE, USB_COL_BG, 1, label);
+}
+
+void ST7789_Handler::init() {
+    _tft.init();
+    _tft.setRotation(2);
+    _tft.fillScreen(USB_COL_BG);
+
+    // Backlight guarantee for battery operation
+    pinMode(TFT_BL_PIN, OUTPUT);
+    digitalWrite(TFT_BL_PIN, HIGH);
+
+    // Header
+    _fillRow(USB_Y_HEADER, USB_H_HEADER, USB_COL_HEADER);
+    const char* title = "USB  MIDI";
+    int titleW = strlen(title) * 12;
+    int titleX = (USB_DISPLAY_W - titleW) / 2;
+    int titleY = USB_Y_HEADER + (USB_H_HEADER - 16) / 2;
+    _drawText(titleX, titleY, USB_COL_WHITE, USB_COL_HEADER, 2, title);
+
+    // Status rows (initial state = waiting/scanning)
+    setUSB(false);
+    setBLE(false);
+
+    // Divider
+    _fillRow(USB_Y_DIVIDER, USB_H_DIVIDER, USB_COL_BG);
+    int lineY = USB_Y_DIVIDER + USB_H_DIVIDER / 2;
+    _tft.drawFastHLine(0, lineY, USB_DISPLAY_W, USB_COL_DIVIDER);
+    const char* lbl = " EVENTS ";
+    int lblW = strlen(lbl) * 6;
+    _drawText((USB_DISPLAY_W - lblW) / 2, USB_Y_DIVIDER + 2,
+              USB_COL_DIVIDER, USB_COL_BG, 1, lbl);
+
+    // Events area — blank
+    _fillRow(USB_Y_EVENTS, USB_N_EVENTS * USB_H_EVENT, USB_COL_BG);
+
+    // Counters bar
+    _fillRow(USB_Y_COUNTERS, USB_H_COUNTERS, USB_COL_HEADER);
+    setCounters(0, 0);
+}
+
+void ST7789_Handler::setUSB(bool connected) {
+    if (connected) {
+        _drawStatusRow(USB_Y_USB, USB_H_USB, USB_COL_GREEN,
+                       "USB  Connected");
+    } else {
+        _drawStatusRow(USB_Y_USB, USB_H_USB, USB_COL_ORANGE,
+                       "USB  Waiting for host...");
+    }
+}
+
+void ST7789_Handler::setBLE(bool connected) {
+    if (connected) {
+        _drawStatusRow(USB_Y_BLE, USB_H_BLE, USB_COL_GREEN,
+                       "BLE  Connected");
+    } else {
+        _drawStatusRow(USB_Y_BLE, USB_H_BLE, USB_COL_ORANGE,
+                       "BLE  Scanning...");
+    }
+}
+
+void ST7789_Handler::pushEvent(uint32_t color, const char* line) {
+    for (int i = USB_N_EVENTS - 1; i > 0; i--) _events[i] = _events[i - 1];
+    _events[0].color = color;
+    strncpy(_events[0].line, line, sizeof(_events[0].line) - 1);
+    _events[0].line[sizeof(_events[0].line) - 1] = '\0';
+    if (_eventCount < USB_N_EVENTS) _eventCount++;
+    _redrawEvents();
+}
+
+void ST7789_Handler::_redrawEvents() {
+    for (int i = 0; i < USB_N_EVENTS; i++) {
+        int y = USB_Y_EVENTS + i * USB_H_EVENT;
+        _fillRow(y, USB_H_EVENT, USB_COL_BG);
+        if (i < _eventCount) {
+            _drawText(USB_MARGIN, y + 6, _events[i].color, USB_COL_BG, 1, _events[i].line);
+        }
+    }
+}
+
+void ST7789_Handler::setCounters(int in, int out) {
+    _fillRow(USB_Y_COUNTERS, USB_H_COUNTERS, USB_COL_HEADER);
+    char buf[20];
+    snprintf(buf, sizeof(buf), "IN : %d", in);
+    _drawText(USB_MARGIN, USB_Y_COUNTERS + 8, USB_COL_WHITE, USB_COL_HEADER, 1, buf);
+    snprintf(buf, sizeof(buf), "OUT: %d", out);
+    _drawText(USB_DISPLAY_W / 2 + 4, USB_Y_COUNTERS + 8, USB_COL_WHITE, USB_COL_HEADER, 1, buf);
+}

--- a/examples/T-Display-S3-USB-Device/ST7789_Handler.h
+++ b/examples/T-Display-S3-USB-Device/ST7789_Handler.h
@@ -1,0 +1,113 @@
+#ifndef ST7789_HANDLER_H
+#define ST7789_HANDLER_H
+
+#include <LovyanGFX.h>
+#include <cstdint>
+
+// Color palette — blue/teal theme for USB
+#define USB_COL_BG        0x0000  // Black background
+#define USB_COL_HEADER    0x19F4  // Dark blue  — header / counter bar
+#define USB_COL_DIVIDER   0x4208  // Dark gray  — divider line / label
+#define USB_COL_WHITE     0xFFFF  // White text
+#define USB_COL_GREEN     0x07E0  // Green  — connected
+#define USB_COL_ORANGE    0xFD20  // Orange — waiting / scanning
+#define USB_COL_RED       0xF800  // Red    — disconnected
+#define USB_COL_CYAN      0x07FF  // Cyan   — NoteOn
+#define USB_COL_GRAY      0x4208  // Gray   — NoteOff
+#define USB_COL_YELLOW    0xFFE0  // Yellow — ControlChange
+#define USB_COL_MAGENTA   0xF81F  // Magenta — PitchBend
+#define USB_COL_LIME      0x07E0  // Green  — ProgramChange
+
+// Layout — portrait 170 × 320
+#define USB_Y_HEADER    0
+#define USB_H_HEADER   34
+#define USB_Y_USB      34
+#define USB_H_USB      22
+#define USB_Y_BLE      56
+#define USB_H_BLE      22
+#define USB_Y_DIVIDER  78
+#define USB_H_DIVIDER  14
+#define USB_Y_EVENTS   92
+#define USB_H_EVENT    20
+#define USB_N_EVENTS   10
+#define USB_Y_COUNTERS (USB_Y_EVENTS + USB_N_EVENTS * USB_H_EVENT)  // = 292
+#define USB_H_COUNTERS 28          // 292 + 28 = 320
+
+#define USB_DISPLAY_W  170
+#define USB_DISPLAY_H  320
+#define USB_MARGIN      4
+
+class ST7789_Handler {
+public:
+    ST7789_Handler();
+    void init();
+
+    // Updates the USB status row.
+    // connected = true  → green dot "USB  Connected"
+    // connected = false → orange dot "USB  Waiting for host..."
+    void setUSB(bool connected);
+
+    // Updates the BLE status row.
+    // connected = true  → green dot "BLE  Connected"
+    // connected = false → orange dot "BLE  Scanning..."
+    void setBLE(bool connected);
+
+    // Pushes a new event to the top of the scrolling list.
+    void pushEvent(uint32_t color, const char* line);
+
+    // Updates the IN / OUT counters in the bottom bar.
+    void setCounters(int in, int out);
+
+private:
+    class LGFX : public lgfx::LGFX_Device {
+    public:
+        LGFX(void) {
+            {
+                auto cfg = _bus_instance.config();
+                cfg.pin_wr = 8;  cfg.pin_rd = 9;  cfg.pin_rs = 7;
+                cfg.pin_d0 = 39; cfg.pin_d1 = 40; cfg.pin_d2 = 41; cfg.pin_d3 = 42;
+                cfg.pin_d4 = 45; cfg.pin_d5 = 46; cfg.pin_d6 = 47; cfg.pin_d7 = 48;
+                _bus_instance.config(cfg);
+                _panel_instance.setBus(&_bus_instance);
+            }
+            {
+                auto cfg = _panel_instance.config();
+                cfg.pin_cs  = 6;  cfg.pin_rst = 5;  cfg.pin_busy = -1;
+                cfg.offset_rotation = 1;
+                cfg.offset_x = 35;
+                cfg.readable = false;  cfg.invert = true;
+                cfg.rgb_order = false; cfg.dlen_16bit = false; cfg.bus_shared = false;
+                cfg.panel_width  = USB_DISPLAY_W;
+                cfg.panel_height = USB_DISPLAY_H;
+                _panel_instance.config(cfg);
+            }
+            setPanel(&_panel_instance);
+            {
+                auto cfg = _light_instance.config();
+                cfg.pin_bl = 38; cfg.invert = false;
+                cfg.freq = 22000; cfg.pwm_channel = 7;
+                _light_instance.config(cfg);
+                _panel_instance.setLight(&_light_instance);
+            }
+        }
+    private:
+        lgfx::Bus_Parallel8  _bus_instance;
+        lgfx::Panel_ST7789   _panel_instance;
+        lgfx::Light_PWM      _light_instance;
+    };
+
+    LGFX _tft;
+
+    struct EventEntry { uint32_t color; char line[32]; };
+    EventEntry _events[USB_N_EVENTS];
+    int        _eventCount;
+
+    void _fillRow(int y, int h, uint32_t bg);
+    void _drawText(int x, int y, uint32_t color, uint32_t bg, uint8_t size, const char* text);
+    void _drawStatusRow(int y, int h, uint32_t dotColor, const char* label);
+    void _redrawEvents();
+};
+
+extern ST7789_Handler display;
+
+#endif // ST7789_HANDLER_H

--- a/examples/T-Display-S3-USB-Device/T-Display-S3-USB-Device.ino
+++ b/examples/T-Display-S3-USB-Device/T-Display-S3-USB-Device.ino
@@ -1,0 +1,136 @@
+// T-Display-S3-USB-Device — ESP32_Host_MIDI example
+//
+// The ESP32-S3 acts as a USB MIDI interface for the connected computer,
+// while simultaneously receiving MIDI from a BLE device (iPhone, iPad,
+// BLE keyboard, etc.).
+//
+// Signal path:
+//   iPhone / iPad  ──BLE──►  ESP32-S3  ──USB──►  Logic / Ableton / Reaper
+//
+// The 1.9" display shows:
+//   - USB connection status (waiting / connected)
+//   - BLE connection status (scanning / connected)
+//   - Scrolling MIDI event log (color-coded by message type)
+//   - IN / OUT event counters
+//
+// Arduino IDE setup (mandatory):
+//   Tools > Board    → T-Display-S3 (or ESP32S3 Dev Module)
+//   Tools > USB Mode → USB-OTG (TinyUSB)   ← required for USB MIDI device
+//
+// The device name shown in the DAW's MIDI port list is configured in
+// mapping.h via USB_MIDI_DEVICE_NAME.
+
+#include <Arduino.h>
+#define ESP32_HOST_MIDI_NO_USB_HOST  // Use USB Device mode, not Host
+#include <ESP32_Host_MIDI.h>
+#include "../../src/USBDeviceConnection.h"
+#include "mapping.h"
+#include "ST7789_Handler.h"
+
+// MUST be global — TinyUSB registers the USB descriptor on construction,
+// before USB.begin() is called. The name comes from mapping.h.
+USBDeviceConnection usbMIDI(USB_MIDI_DEVICE_NAME);
+
+static int    lastEventIndex = -1;
+static int    inCount        = 0;
+static int    outCount       = 0;
+static bool   lastBLE        = false;
+static unsigned long lastStatusCheck = 0;
+
+// ---- helpers -----------------------------------------------------------
+
+static uint32_t eventColor(const std::string& s) {
+    if (s == "NoteOn")        return USB_COL_CYAN;
+    if (s == "NoteOff")       return USB_COL_GRAY;
+    if (s == "ControlChange") return USB_COL_YELLOW;
+    if (s == "PitchBend")     return USB_COL_MAGENTA;
+    if (s == "ProgramChange") return USB_COL_LIME;
+    return USB_COL_WHITE;
+}
+
+static void formatEvent(const MIDIEventData& ev, char* buf, int len) {
+    if (ev.status == "NoteOn") {
+        snprintf(buf, len, "NOTE+  %-3s  v=%-3d  ch%d",
+                 ev.noteOctave.c_str(), ev.velocity, ev.channel);
+    } else if (ev.status == "NoteOff") {
+        snprintf(buf, len, "NOTE-  %-3s  v=%-3d  ch%d",
+                 ev.noteOctave.c_str(), ev.velocity, ev.channel);
+    } else if (ev.status == "ControlChange") {
+        snprintf(buf, len, "CC#%-3d  v=%-3d        ch%d",
+                 ev.note, ev.velocity, ev.channel);
+    } else if (ev.status == "PitchBend") {
+        snprintf(buf, len, "PB  %+6d             ch%d",
+                 ev.pitchBend - 8192, ev.channel);
+    } else if (ev.status == "ProgramChange") {
+        snprintf(buf, len, "PC   prog=%-3d          ch%d",
+                 ev.note, ev.channel);
+    } else {
+        snprintf(buf, len, "%-8s                ch%d",
+                 ev.status.c_str(), ev.channel);
+    }
+}
+
+// ---- setup / loop ------------------------------------------------------
+
+void setup() {
+    pinMode(PIN_POWER_ON, OUTPUT);
+    digitalWrite(PIN_POWER_ON, HIGH);
+
+    display.init();
+
+    // Register USB Device transport (BLE is registered automatically by begin()).
+    midiHandler.addTransport(&usbMIDI);
+
+    // Start USB stack (enumerates on the host as a MIDI device).
+    usbMIDI.begin();
+
+    MIDIHandlerConfig cfg;
+    cfg.maxEvents = 40;
+    midiHandler.begin(cfg);
+
+    display.setBLE(false);
+    display.setUSB(false);
+}
+
+void loop() {
+    midiHandler.task();
+
+    // Refresh connection dots every 2 s.
+    if (millis() - lastStatusCheck >= 2000) {
+        lastStatusCheck = millis();
+
+        bool ble = midiHandler.isBleConnected();
+        if (ble != lastBLE) {
+            lastBLE = ble;
+            display.setBLE(ble);
+        }
+
+        // USB MIDI device has no per-session state — show "connected" once
+        // begin() has been called (the port is always visible to the host).
+        display.setUSB(usbMIDI.isConnected());
+    }
+
+    // Process new MIDI events.
+    const auto& queue = midiHandler.getQueue();
+    bool countersChanged = false;
+
+    for (const auto& ev : queue) {
+        if (ev.index <= lastEventIndex) continue;
+        lastEventIndex = ev.index;
+        inCount++;
+        countersChanged = true;
+
+        char line[32];
+        formatEvent(ev, line, sizeof(line));
+        display.pushEvent(eventColor(ev.status), line);
+
+        // Forward every event received (from BLE or USB host) to the other side.
+        // BLE → forward to USB; USB → forward to BLE (if connected).
+        // midiHandler forwards automatically to all registered transports.
+        outCount++;
+    }
+
+    if (countersChanged) {
+        display.setCounters(inCount, outCount);
+    }
+}

--- a/examples/T-Display-S3-USB-Device/mapping.h
+++ b/examples/T-Display-S3-USB-Device/mapping.h
@@ -1,0 +1,26 @@
+#ifndef MAPPING_H
+#define MAPPING_H
+
+// Pin mapping for T-Display S3
+
+// USB Host
+#define USB_DP_PIN   19
+#define USB_DN_PIN   18
+
+// ST7789 Display
+#define TFT_CS_PIN    6
+#define TFT_DC_PIN    16
+#define TFT_RST_PIN   5
+#define TFT_BL_PIN    38
+
+// Board hardware
+#define PIN_POWER_ON 15
+#define PIN_BUTTON_1  0
+#define PIN_BUTTON_2 14
+
+// ---- USB MIDI device name ---------------------------------------------
+// This is the name shown in macOS "Audio MIDI Setup", Windows Device Manager,
+// and every DAW's MIDI port list. Max 32 characters.
+#define USB_MIDI_DEVICE_NAME  "ESP32 MIDI"
+
+#endif // MAPPING_H

--- a/platformio.ini
+++ b/platformio.ini
@@ -372,3 +372,22 @@ lib_ignore =
     PCF8575 library
     PCA95x5
     lvgl
+
+[env:T-Display-S3-USB-Device]
+build_flags =
+    -DLV_LVGL_H_INCLUDE_SIMPLE
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DDISABLE_ALL_LIBRARY_WARNINGS
+    -DARDUINO_USB_MODE=0
+    -DTOUCH_MODULES_CST_MUTUAL
+lib_deps =
+    lovyan03/LovyanGFX
+lib_ignore =
+    GFX Library for Arduino
+    TFT_eSPI
+    arduino-nofrendo
+    Adafruit MPR121
+    DabbleESP32
+    PCF8575 library
+    PCA95x5
+    lvgl


### PR DESCRIPTION
## Summary

Adds a **T-Display-S3-USB-Device** example: turns the T-Display-S3 into a BLE-to-USB MIDI bridge. Receive MIDI wirelessly via BLE and output it as a class-compliant USB MIDI device — no drivers needed.

Part of the ESP32_Host_MIDI example series (see #327 for the full project showcase).

### What it does

- **BLE MIDI receiver**: Connects to BLE MIDI keyboards/controllers
- **USB MIDI device output**: The ESP32-S3 appears as a USB MIDI interface on your computer
- **Bridge mode**: BLE → USB in real-time, making wireless controllers work with any DAW
- **Visual feedback**: Shows MIDI traffic and connection status on the display
- Uses `ARDUINO_USB_MODE=0` (TinyUSB) for USB MIDI device class

### Files added

- `examples/T-Display-S3-USB-Device/` — Complete example with source

Uses libraries already bundled in `lib/` from #328.

**Modified:**
- `platformio.ini` — Added `[env:T-Display-S3-USB-Device]` with `ARDUINO_USB_MODE=0`
- `README.md` — Added example to the tree

### Related

- #327 — Community showcase with all 11 MIDI examples
- #328 — First example (T-Display-S3-Piano) + bundled libraries

### Hardware required

- LilyGO T-Display-S3 (connected to computer via USB)
- Any BLE MIDI controller (wireless keyboard, pad controller, etc.)